### PR TITLE
Changed 'ERR_LIB_CMS' to 'ERR_LIB_ESS' in the following line: ERR_raise(ERR_LIB_CMS, ESS_R_MISSING_SIGNING_CERTIFICATE_ATTRIBUTE);

### DIFF
--- a/crypto/ess/ess_lib.c
+++ b/crypto/ess/ess_lib.c
@@ -346,7 +346,7 @@ int OSSL_ESS_check_signing_certs(const ESS_SIGNING_CERT *ss,
     int i, ret;
 
     if (require_signing_cert && ss == NULL && ssv2 == NULL) {
-        ERR_raise(ERR_LIB_CMS, ESS_R_MISSING_SIGNING_CERTIFICATE_ATTRIBUTE);
+        ERR_raise(ERR_LIB_ESS, ESS_R_MISSING_SIGNING_CERTIFICATE_ATTRIBUTE);
         return -1;
     }
     if (n_v1 == 0 || n_v2 == 0) {


### PR DESCRIPTION
The original line of code in the openssl/crypto/ess/ess_lib.c file is:
ERR_raise(ERR_LIB_CMS, ESS_R_MISSING_SIGNING_CERTIFICATE_ATTRIBUTE); 
This line of code has been changed to:
ERR_raise(ERR_LIB_ESS, ESS_R_MISSING_SIGNING_CERTIFICATE_ATTRIBUTE);

This is a fix for issue #24224


CLA: trivial